### PR TITLE
Remove some warnings and fix build on linux

### DIFF
--- a/creature.h
+++ b/creature.h
@@ -17,6 +17,8 @@
 #ifndef CREATURE_H__
 #define CREATURE_H__
 
+#include <stdbool.h>
+
 struct level;
 
 enum race {

--- a/level.c
+++ b/level.c
@@ -15,15 +15,18 @@
  */
 
 #include <errno.h>
-#include <string.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
-#include "ui.h"
-#include "level.h"
+#include <sys/types.h>
+
+#include "config.h"
 #include "creature.h"
+#include "level.h"
 #include "rng.h"
+#include "ui.h"
 
 static void level_add_stair(struct level *, bool);
 

--- a/level.h
+++ b/level.h
@@ -17,6 +17,9 @@
 #ifndef LEVEL_H__
 #define LEVEL_H__
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #define MAXROWS 22
 #define MAXCOLS 80
 

--- a/options.h
+++ b/options.h
@@ -17,6 +17,8 @@
 #ifndef OPTIONS_H__
 #define OPTIONS_H__
 
+#include <stdbool.h>
+
 enum option {
 	O_COLORS,
 	O_DECGRAPHICS,


### PR DESCRIPTION
The build was broken because of missing declaration of bool and ssize_t.
The branch removes the warning on the switch fallthrought though.